### PR TITLE
Fixed DateTime Bug

### DIFF
--- a/PSDokuWiki/Public/Get-DokuAllPage.ps1
+++ b/PSDokuWiki/Public/Get-DokuAllPage.ps1
@@ -11,11 +11,14 @@
             if ($APIResponse.CompletedSuccessfully -eq $true) {
                 $MemberNodes = ($APIResponse.XMLPayloadResponse | Select-Xml -XPath "//struct").Node
                 foreach ($node in $MemberNodes) {
+					$LastModified = (($node.member)[3]).value.innertext
+					$ConvertedDate = $LastModified.substring(0,4) + '-' + $LastModified.substring(4,2) + '-' + -join $LastModified[6..50]
                     $PageObject = [PSCustomObject]@{
                         FullName     = (($node.member)[0]).value.InnerText
                         Acl          = (($node.member)[1]).value.InnerText
                         Size         = (($node.member)[2]).value.InnerText
-                        LastModified = Get-Date -Date ((($node.member)[3]).value.InnerText)
+                        # LastModified = Get-Date -Date ((($node.member)[3]).value.InnerText)
+                        LastModified = Get-Date -Date ($ConvertedDate)
                         LastModifiedRaw = (($node.member)[3]).value.InnerText
                         PageName        = (((($node.member)[0]).value.InnerText) -split ":")[-1]
                         ParentNamespace = (((($node.member)[0]).value.InnerText) -split ":")[-2]

--- a/PSDokuWiki/Public/Get-DokuAttachmentInfo.ps1
+++ b/PSDokuWiki/Public/Get-DokuAttachmentInfo.ps1
@@ -20,10 +20,12 @@
                 $APIResponse = Invoke-DokuApiCall -MethodName 'wiki.getAttachmentInfo' -MethodParameters @($attachmentName)
                 if ($APIResponse.CompletedSuccessfully -eq $true) {
                     $ArrayValues = ($APIResponse.XMLPayloadResponse | Select-Xml -XPath "//struct").Node.Member.Value.Innertext
+                    $ConvertedDate = $ArrayValues[0].substring(0,4) + '-' + $ArrayValues[0].substring(4,2) + '-' + -join $ArrayValues[0][6..50]
                     $attachmentObject = [PSCustomObject]@{
                         FullName        = $attachmentName
                         Size            = $ArrayValues[1]
-                        LastModified    = Get-Date -Date ($ArrayValues[0])
+                        #  LastModified    = Get-Date -Date ($ArrayValues[0])
+                        LastModified    = Get-Date -Date ($ConvertedDate)
                         FileName        = ($attachmentName -split ":")[-1]
                         ParentNamespace = ($attachmentName -split ":")[-2]
                         RootNamespace   = if (($attachmentName -split ":")[0] -eq $attachmentName) {"::"} else {($attachmentName -split ":")[0]}

--- a/PSDokuWiki/Public/Get-DokuAttachmentList.ps1
+++ b/PSDokuWiki/Public/Get-DokuAttachmentList.ps1
@@ -23,6 +23,8 @@
 				if ($APIResponse.CompletedSuccessfully -eq $true) {
 					$MemberNodes = ($APIResponse.XMLPayloadResponse| Select-Xml -XPath "//struct").Node
 					foreach ($node in $MemberNodes) {
+						$LastModified = (($node.member)[7]).value.innertext
+						$ConvertedDate = $LastModified.substring(0,4) + '-' + $LastModified.substring(4,2) + '-' + -join $LastModified[6..50]
 						$MediaObject = [PSCustomObject]@{
 							FullName = ((($node.member)[0]).value.innertext)
 							Name = (($node.member)[1]).value.innertext
@@ -31,7 +33,8 @@
 							IsWritable = [boolean](($node.member)[4]).value.innertext
 							IsImage = [boolean](($node.member)[5]).value.innertext
 							Acl = [int](($node.member)[6]).value.innertext
-							LastModified = [datetime](($node.member)[7]).value.innertext
+							# LastModified = [datetime](($node.member)[7]).value.innertext
+							LastModified = [datetime]$ConvertedDate
 							ParentNamespace = (((($node.member)[0]).value.innertext) -split ":")[-2]
 							RootNamespace = (((($node.member)[0]).value.innertext) -split ":")[0]
 						}

--- a/PSDokuWiki/Public/Get-DokuPageInfo.ps1
+++ b/PSDokuWiki/Public/Get-DokuPageInfo.ps1
@@ -20,9 +20,11 @@
 				$APIResponse = Invoke-DokuApiCall -MethodName 'wiki.getPageInfo' -MethodParameters @($PageName)
 				if ($APIResponse.CompletedSuccessfully -eq $true) {
 					$ArrayValues = ($APIResponse.XMLPayloadResponse | Select-Xml -XPath "//struct").Node.Member.Value.Innertext
+					$ConvertedDate = $ArrayValues[1].substring(0,4) + '-' + $ArrayValues[1].substring(4,2) + '-' + -join $ArrayValues[1][6..50]
 					$PageObject = [PSCustomObject]@{
 						FullName = $PageName
-						LastModified = Get-Date -Date ($ArrayValues[1])
+						# LastModified = Get-Date -Date ($ArrayValues[1])
+						LastModified = Get-Date -Date ($ConvertedDate)
 						Author = $ArrayValues[2]
 						VersionTimestamp = $ArrayValues[3]
 						PageName = ($PageName -split ":")[-1]


### PR DESCRIPTION
DokuWiki seemingly made a change to their Datetime formatting which caused errors in some Cmdlets. 
Examples:

Error Message Get-DokuAttachmentInfo:

>Line |
>   27 |  …                    LastModified    = Get-Date -Date ($ArrayValues[0])
    |                                                        ~~~~~~~~~~~~~~~~~
     | Cannot bind parameter 'Date'. Cannot convert value "20220801T18:13:39+0000" to type "System.DateTime". Error:
     | "String '20220801T18:13:39+0000' was not recognized as a valid DateTime."


Error Message Get-DokuAttachmentList:


>Line |
  26 |                          $MediaObject = [PSCustomObject]@{
     |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot convert value "20220401T10:55:07+0000" to type "System.DateTime". Error: "String '20220401T10:55:07+0000'
     | was not recognized as a valid DateTime."

